### PR TITLE
Fix/linq extension.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ using Tekla.Structures.Model;
 ```csharp
 using TSMUI = Tekla.Structures.Model.UI;
 using Tekla.Structures.Model;
-using Tekla.Extensions;
+using Tekla.Extension;
         public double GetWeight()
         {
             //Summing all weight of all parts in Assembly

--- a/Tekla.Extension/LinqExtension.cs
+++ b/Tekla.Extension/LinqExtension.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Tekla.Structures.Model;
 
-namespace Tekla.Extension.LinqExtension;
+namespace Tekla.Extension;
 
 /// <summary>
 /// Extension class for queries in model


### PR DESCRIPTION
The was a different namespace for the LinqExtension.cs methods, also in the README.md contained a little bit different namespace which is not in the library currently. Whole old code/new code is a bit confusing since in old code you go through all selected assemblies and overwrite the allWeight variable, but in Linq example you just take the first assembly and continue calculations on it. But technically its fine.
Там был другой неймспейс для LinqExtension.cs, а также в README.md тоже путаница. Сам пример немного сбивает с толку, с тем, что в примере без Linq проходишься по всем выбранным маркам перезаписывая вес, а в Linq берешь первую попавшую. Но технически это не ошибка конечно.