### PR TITLE
added GetProfileType Part extension method and ProfileType enum

### DIFF
--- a/Tekla.Extension/Enums/ProfileType.cs
+++ b/Tekla.Extension/Enums/ProfileType.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tekla.Extension
+{
+    /// <summary>
+    /// Enum for storing PROFILE_TYPE values as per https://support.tekla.com/doc/tekla-structures/2023/profile_type.
+    /// </summary>
+    public enum ProfileType : int
+    {
+        /// <summary>
+        /// Corresponding API sting value is "B".
+        /// </summary>
+        [Description("B")]
+        Plate,
+
+        /// <summary>
+        /// I - beam. Corresponding API sting value is "I".
+        /// </summary>
+        [Description("I")]
+        Ibeam,
+
+        /// <summary>
+        /// L - shaped profile. Corresponding API sting value is "L".
+        /// </summary>
+        [Description("L")]
+        Angle,
+        
+        /// <summary>
+        /// [ - shaped profile. Corresponding API sting value is "U".
+        /// </summary>
+        [Description("U")]
+        Channel,
+        
+        /// <summary>
+        /// Round profile. Corresponding API sting value is "RU".
+        /// </summary>
+        [Description("RU")]
+        RoundBar,
+        
+        /// <summary>
+        /// o - shaped profile. Corresponding API sting value is "RO".
+        /// </summary>
+        [Description("RO")]
+        RoundTube,
+        
+        /// <summary>
+        /// ⎕ - shaped profile. Corresponding API sting value is "M".
+        /// </summary>
+        [Description("M")]
+        RectangularTube,
+
+        /// <summary>
+        /// ∁ - shaped cold formed profile. Corresponding API sting value is "C".
+        /// </summary>
+        [Description("C")]
+        CFChannel,
+        
+        /// <summary>
+        /// T - shaped profile. Corresponding API sting value is "T".
+        /// </summary>
+        [Description("T")]
+        Tbeam,
+        
+        /// <summary>
+        /// Z and rest shaped profiles. Corresponding API sting value is "Z".
+        /// </summary>
+        [Description("Z")]
+        Zbeam
+    }
+}

--- a/Tekla.Extension/Enums/ProfileType.cs
+++ b/Tekla.Extension/Enums/ProfileType.cs
@@ -70,6 +70,12 @@ namespace Tekla.Extension
         /// Z and rest shaped profiles. Corresponding API sting value is "Z".
         /// </summary>
         [Description("Z")]
-        Zbeam
+        Zbeam,
+
+        /// <summary>
+        /// Profile string is not supported. Unknown corresponding API sting value.
+        /// </summary>
+        [Description("Unknown")]
+        Unknown
     }
 }

--- a/Tekla.Extension/PartExtension.cs
+++ b/Tekla.Extension/PartExtension.cs
@@ -6,6 +6,7 @@ using Tekla.Structures.Geometry3d;
 using Tekla.Structures.Model;
 using Tekla.Structures.Solid;
 using SR = System.Reflection;
+using Tekla.Extension.Services;
 
 namespace Tekla.Extension
 {
@@ -84,6 +85,15 @@ namespace Tekla.Extension
             IEnumerable<Guid> welds1 = part1.GetWelds().ToIEnumerable<BaseWeld>().Select(b => b.Identifier.GUID);
             IEnumerable<Guid> welds2 = part2.GetWelds().ToIEnumerable<BaseWeld>().Select(b => b.Identifier.GUID);
             return welds1.Intersect(welds2).Count() > 0;
+        }
+        /// <summary>
+        /// Gets profile type property and returns custom enum to work with profile type filtering.
+        /// </summary>
+        public static ProfileType GetProfileType(this Part part)
+        {
+            string profTypeStr = string.Empty;
+            part.GetReportProperty("PROFILE_TYPE", ref profTypeStr);
+            return ProfileTypeEnumConverter.GetProfileTypeFromString(profTypeStr);
         }
     }
 }

--- a/Tekla.Extension/Services/ProfileTypeEnumConverter.cs
+++ b/Tekla.Extension/Services/ProfileTypeEnumConverter.cs
@@ -13,7 +13,6 @@ public static class ProfileTypeEnumConverter
     /// Converts string to ProfileType.
     /// </summary>
     /// <param name="str">String value API is working with.</param>
-    /// <returns>May return -1 if the string is not supported in the ProfileType Enum</returns>
     public static ProfileType GetProfileTypeFromString(string str)
     {
         switch (str)
@@ -39,7 +38,7 @@ public static class ProfileTypeEnumConverter
             case "Z":
                 return ProfileType.Zbeam;
             default:
-                return (ProfileType)(-1);
+                return ProfileType.Unknown;
         }
     }
 
@@ -73,7 +72,7 @@ public static class ProfileTypeEnumConverter
             case ProfileType.Zbeam:
                 return "Z";
             default:
-                return "";
+                return "Unknown";
         }
     }
 }

--- a/Tekla.Extension/Services/ProfileTypeEnumConverter.cs
+++ b/Tekla.Extension/Services/ProfileTypeEnumConverter.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tekla.Extension.Services;
+
+public static class ProfileTypeEnumConverter
+{
+
+    /// <summary>
+    /// Converts string to ProfileType.
+    /// </summary>
+    /// <param name="str">String value API is working with.</param>
+    /// <returns>May return -1 if the string is not supported in the ProfileType Enum</returns>
+    public static ProfileType GetProfileTypeFromString(string str)
+    {
+        switch (str)
+        {
+            case "B":
+                return ProfileType.Plate;
+            case "I":
+                return ProfileType.Ibeam;
+            case "L":
+                return ProfileType.Angle;
+            case "U":
+                return ProfileType.Channel;
+            case "RU":
+                return ProfileType.RoundBar;
+            case "RO":
+                return ProfileType.RoundTube;
+            case "M":
+                return ProfileType.RectangularTube;
+            case "C":
+                return ProfileType.CFChannel;
+            case "T":
+                return ProfileType.Tbeam;
+            case "Z":
+                return ProfileType.Zbeam;
+            default:
+                return (ProfileType)(-1);
+        }
+    }
+
+    /// <summary>
+    /// Converts ProfileType back to string.
+    /// </summary>
+    /// <param name="profileType"></param>
+    /// <returns>String corresponding to Enum</returns>
+    public static string GetStringValueFromProfileType(ProfileType profileType)
+    {
+        switch (profileType)
+        {
+            case ProfileType.Plate:
+                return "B";
+            case ProfileType.Ibeam:
+                return "I";
+            case ProfileType.Angle:
+                return "L";
+            case ProfileType.Channel:
+                return "U";
+            case ProfileType.RoundBar:
+                return "RU";
+            case ProfileType.RoundTube:
+                return "RO";
+            case ProfileType.RectangularTube:
+                return "M";
+            case ProfileType.CFChannel:
+                return "C";
+            case ProfileType.Tbeam:
+                return "T";
+            case ProfileType.Zbeam:
+                return "Z";
+            default:
+                return "";
+        }
+    }
+}

--- a/Tekla.Extension/Tekla.Extension.csproj
+++ b/Tekla.Extension/Tekla.Extension.csproj
@@ -96,6 +96,7 @@
     <Compile Include="AssemblyExtension.cs" />
     <Compile Include="BoltExtension.cs" />
     <Compile Include="Drawer.cs" />
+    <Compile Include="Enums\ProfileType.cs" />
     <Compile Include="LineExtension.cs" />
     <Compile Include="LinqExtension.cs" />
     <Compile Include="ModelObjectExtension.cs" />
@@ -103,6 +104,7 @@
     <Compile Include="PartExtension.cs" />
     <Compile Include="PointExtension.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\ProfileTypeEnumConverter.cs" />
     <Compile Include="SolidExtension.cs" />
     <Compile Include="VectorExtension.cs" />
   </ItemGroup>


### PR DESCRIPTION
I added Part extension method GetProfileType() and ProfileType enum with a simplest converter. Enum still has string values in its attributes in case we will need to parse them.